### PR TITLE
feat: 카카오 OAuth 로그인 쿠키 설정 및 프론트 리다이렉트 처리

### DIFF
--- a/src/main/java/com/cluvy/auth/controller/AuthController.java
+++ b/src/main/java/com/cluvy/auth/controller/AuthController.java
@@ -4,10 +4,17 @@ import com.cluvy.auth.dto.*;
 import com.cluvy.auth.response.ApiResponse;
 import com.cluvy.auth.service.AuthService;
 import com.cluvy.auth.util.JwtUtil;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
 
 @RestController
 @RequestMapping("/api/auth")
@@ -59,24 +66,65 @@ public class AuthController {
     }
 
     /**
-     * 카카오 인가 코드를 받고, 카카오 API를 호출해 엑세스 토큰을 받은 후 소셜 로그인
+     * 카카오 소셜 로그인 콜백 엔드포인트
      *
-     * @param code 인가 코드
-     * @return jwt와 refresh token을 포함한 SocialLoginResponse
+     * 1. 카카오로부터 전달받은 인가 코드를 확인
+     * 2. 인가 코드를 사용해 카카오 API에서 액세스 토큰 발급
+     * 3. 액세스 토큰으로 소셜 로그인 처리 후 JWT 생성
+     * 4. JWT를 쿠키에 담아 브라우저에 저장
+     * 5. 브라우저를 프론트엔드 페이지로 리다이렉트
+     *
+     * 주의:
+     * - 프론트엔드에서는 JSON body가 아니라 쿠키를 통해 로그인 상태를 확인
+     * - 개발 환경에서는 Secure=false, 배포 시 HTTPS에서는 true로 설정 필요
+     *
+     * @param code 카카오에서 전달받은 인가 코드
+     * @return 302 Redirect 응답 + JWT 쿠키
      */
     @GetMapping("/oauth")
-    public ApiResponse<SocialLoginResponse> kakaoCallback(@RequestParam String code) throws Exception {
-        // kauth로 액세스 토큰 요청
+    public ResponseEntity<?> kakaoCallback(@RequestParam String code) throws Exception {
+
+        // 1. 인가 코드 확인
         log.info("인가 코드: {}", code);
+
+        // 2. 카카오로 액세스 토큰 요청
         String accessToken = authService.getAccessTokenFromKakao(code);
+        log.info("액세스 토큰: {}", accessToken);
 
-        // kapi로 카카오 로그인
-        log.info("액세스 토큰: " + accessToken);
-        SocialLoginResponse loginResponse = authService.socialLogin(new SocialLoginRequest("kakao", accessToken));
-
-        // jwt 포함 응답
+        // 3. 카카오 로그인 처리
+        SocialLoginResponse loginResponse = authService.socialLogin(
+                new SocialLoginRequest("kakao", accessToken));
         log.info("로그인 응답: {}", loginResponse);
-        return ApiResponse.onSuccess(loginResponse);
+
+        // 4. 쿠키 생성 (HttpOnly, Secure, SameSite)
+        // Access Token 쿠키
+        ResponseCookie accessCookie = ResponseCookie.from("access_token", loginResponse.getAccessToken())
+                .httpOnly(true)
+                .secure(false) // HTTPS 환경에서는 true
+                .path("/")
+                .maxAge(60 * 60) // 1시간
+                .sameSite("Lax")
+                .build();
+
+        // Refresh Token 쿠키
+        ResponseCookie refreshCookie = ResponseCookie.from("refresh_token", loginResponse.getRefreshToken())
+                .httpOnly(true)
+                .secure(false) // HTTPS 환경에서는 true
+                .path("/")
+                .maxAge(60 * 60 * 24 * 7)  // 7일
+                .sameSite("Lax")
+                .build();
+
+        // 헤더에 두 쿠키 모두 추가
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.SET_COOKIE, accessCookie.toString());
+        headers.add(HttpHeaders.SET_COOKIE, refreshCookie.toString());
+        headers.add(HttpHeaders.LOCATION, "http://localhost:3000/"); // 프론트 주소
+
+        // 6. 302 Redirect 응답 반환
+        return ResponseEntity.status(HttpStatus.FOUND)
+                .headers(headers)
+                .build();
     }
 
     /**


### PR DESCRIPTION
- ApiResponse 대신 ResponseEntity를 사용함. 해당 건에 대해선 공용 블로그의 글을 참조하길 바람.
- 현재 프론트엔드의 URL은 하드코딩되어 있음. 프론트엔드와 협의하여 URL이 확정되면 환경 변수를 사용하는 것으로 변경 예정